### PR TITLE
Fix set-output usages as per GH guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
           echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
           echo "GO_VERSION_LIST=$GO_VERSION_LIST" >> $GITHUB_ENV
       - id: export-go-version
-        run: echo "::set-output name=go_version::$GO_VERSION"
+        run: echo "go_version=GO_VERSION" >> $GITHUB_OUTPUT
       - id: export-go-version-list
-        run: echo "::set-output name=go_version_list::$GO_VERSION_LIST"
+        run: echo "go_version_list=$GO_VERSION_LIST" >> $GITHUB_OUTPUT
     outputs:
       go_version: ${{ steps.export-go-version.outputs.go_version }}
       go_version_list: ${{ steps.export-go-version-list.outputs.go_version_list }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
         run: echo "go_version=${GO_VERSION}" >> $GITHUB_OUTPUT
       - id: export-go-version-list
         run: echo "go_version_list=${GO_VERSION_LIST}" >> $GITHUB_OUTPUT
+    outputs:
+      go_version: ${{ steps.export-go-version.outputs.go_version }}
+      go_version_list: ${{ steps.export-go-version-list.outputs.go_version_list }}
   linter:
     needs: load-versions
     name: Run linters

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
           echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
           echo "GO_VERSION_LIST=$GO_VERSION_LIST" >> $GITHUB_ENV
       - id: export-go-version
-        run: echo "go_version=GO_VERSION" >> $GITHUB_OUTPUT
+        run: echo "go_version=${GO_VERSION}" >> $GITHUB_OUTPUT
       - id: export-go-version-list
-        run: echo "go_version_list=$GO_VERSION_LIST" >> $GITHUB_OUTPUT
+        run: echo "go_version_list=${GO_VERSION_LIST}" >> $GITHUB_OUTPUT
   linter:
     needs: load-versions
     name: Run linters

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,6 @@ jobs:
         run: echo "go_version=GO_VERSION" >> $GITHUB_OUTPUT
       - id: export-go-version-list
         run: echo "go_version_list=$GO_VERSION_LIST" >> $GITHUB_OUTPUT
-    outputs:
-      go_version: ${{ steps.export-go-version.outputs.go_version }}
-      go_version_list: ${{ steps.export-go-version-list.outputs.go_version_list }}
   linter:
     needs: load-versions
     name: Run linters

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,15 @@ jobs:
       - id: load-versions
         run: |
           source $GITHUB_WORKSPACE/versions.env
+          # env vars
           echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
           echo "GO_VERSION_LIST=$GO_VERSION_LIST" >> $GITHUB_ENV
-      - id: export-go-version
-        run: echo "go_version=${GO_VERSION}" >> $GITHUB_OUTPUT
-      - id: export-go-version-list
-        run: echo "go_version_list=${GO_VERSION_LIST}" >> $GITHUB_OUTPUT
+          # outputs
+          echo "go_version=${GO_VERSION}" >> $GITHUB_OUTPUT
+          echo "go_version_list=${GO_VERSION_LIST}" >> $GITHUB_OUTPUT
     outputs:
-      go_version: ${{ steps.export-go-version.outputs.go_version }}
-      go_version_list: ${{ steps.export-go-version-list.outputs.go_version_list }}
+      go_version: ${{ steps.load-versions.outputs.go_version }}
+      go_version_list: ${{ steps.load-versions.outputs.go_version_list }}
   linter:
     needs: load-versions
     name: Run linters


### PR DESCRIPTION
Signed-off-by: Jose Luis Vazquez Gonzalez <josvaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Fix warning due to `set-output` usages due to this GitHub change:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

**Benefits**

No spurious warnings, no noise and no issue desensitization now. No sudden CI pipeline broken later.